### PR TITLE
Can not enter rows less than 1

### DIFF
--- a/fuel/app/views/colorpicker/colorTable.php
+++ b/fuel/app/views/colorpicker/colorTable.php
@@ -19,7 +19,7 @@
                 $rows = Input::get('rows');
                 $colors = Input::get('colors');
                 $errors = [];
-                if ($rows > 26) {
+                if ($rows > 26 or $rows < 1) {
                     $errors[] = "Rows: Please enter a number between 1 and 26";
                 }
                 if ($colors > 10 or $colors < 1) {


### PR DESCRIPTION
We previously had it so you could enter the number 0 and negative numbers for rows. Peep here... https://cs.colostate.edu:4444/~ckisylia/CS312-Project/fuelviews/index.php/colorpicker/table?rows=1&colors=2&submit=Submit
